### PR TITLE
Suppress Mac OS X Dock Icon

### DIFF
--- a/DiabloMiner-OSX.sh
+++ b/DiabloMiner-OSX.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 export GPU_USE_SYNC_OBJECTS=1
-java -cp target/libs/*:target/DiabloMiner-0.0.1-SNAPSHOT.jar -Djava.library.path=target/libs/natives/macosx com.diablominer.DiabloMiner.DiabloMiner $@
+java -cp target/libs/*:target/DiabloMiner-0.0.1-SNAPSHOT.jar -Djava.awt.headless=true -Djava.library.path=target/libs/natives/macosx com.diablominer.DiabloMiner.DiabloMiner $@


### PR DESCRIPTION
I added a system property to the DiabloMiner-OSX.sh script to suppress the dock icon.  Since the app contains no UI and is launched via shell script from a terminal, I feel that it is appropriate for it not have a Dock Application Icon and execute completely within the shell.
