### PR TITLE
remove .5s delay from long polling loop

### DIFF
--- a/src/main/java/com/diablominer/DiabloMiner/DiabloMiner.java
+++ b/src/main/java/com/diablominer/DiabloMiner/DiabloMiner.java
@@ -921,15 +921,13 @@ class DiabloMiner {
           try {
             getWorkAsync.queueIncoming.set(doJSONRPC(true, getWorkMessage));
             debug(queryUrl.getHost() + ": Long poll returned");
+            forceUpdate();
           } catch(IOException e) {
             error("Cannot connect to " + queryUrl.getHost() + ": " + e.getLocalizedMessage());
+            try {
+              Thread.sleep(500);
+            } catch (InterruptedException f) {}
           }
-
-          forceUpdate();
-
-          try {
-            Thread.sleep(500);
-          } catch (InterruptedException e) {}
         }
       }
     }


### PR DESCRIPTION
This will help p2pool greatly, since it updates work 120 times faster than the block chain, but will also give a marginal benefit to normal miners.
