### PR TITLE
Avoid float comparison bugs.

### DIFF
--- a/src/main/java/com/diablominer/DiabloMiner/DeviceState/GPUDeviceState.java
+++ b/src/main/java/com/diablominer/DiabloMiner/DeviceState/GPUDeviceState.java
@@ -45,7 +45,7 @@ import com.diablominer.DiabloMiner.NetworkState.WorkState;
 public class GPUDeviceState extends DeviceState {
 	final static int OUTPUTS = 16;
 
-	final float platform_version;
+	final PlatformVersion platform_version;
 	final CLDevice device;
 	final CLContext context;
 	final CLKernel kernel;
@@ -65,7 +65,7 @@ public class GPUDeviceState extends DeviceState {
 
 	GPUHardwareType hardwareType;
 
-	GPUDeviceState(GPUHardwareType hardwareType, String deviceName, CLPlatform platform, float platform_version, CLDevice device) throws DiabloMinerFatalException {
+	GPUDeviceState(GPUHardwareType hardwareType, String deviceName, CLPlatform platform, PlatformVersion platform_version, CLDevice device) throws DiabloMinerFatalException {
 		this.platform_version = platform_version;
 		this.hardwareType = hardwareType;
 		this.diabloMiner = hardwareType.getDiabloMiner();
@@ -331,7 +331,7 @@ public class GPUDeviceState extends DeviceState {
 
 			blankinit.rewind();
 
-			if(platform_version == 1.1)
+			if(platform_version == PlatformVersion.V1_1)
 				blank = CL10.clCreateBuffer(context, CL10.CL_MEM_COPY_HOST_PTR | CL10.CL_MEM_READ_ONLY, blankinit, errBuffer);
 			else
 				blank = CL10.clCreateBuffer(context, CL10.CL_MEM_COPY_HOST_PTR | CL10.CL_MEM_READ_ONLY | CL12.CL_MEM_HOST_NO_ACCESS, blankinit, errBuffer);
@@ -342,7 +342,7 @@ public class GPUDeviceState extends DeviceState {
 			blankinit.rewind();
 
 			for(int i = 0; i < 2; i++) {
-				if(platform_version == 1.1)
+				if(platform_version == PlatformVersion.V1_1)
 					output[i] = CL10.clCreateBuffer(context, CL10.CL_MEM_COPY_HOST_PTR | CL10.CL_MEM_WRITE_ONLY, blankinit, errBuffer);
 				else
 					output[i] = CL10.clCreateBuffer(context, CL10.CL_MEM_COPY_HOST_PTR | CL10.CL_MEM_WRITE_ONLY | CL12.CL_MEM_HOST_READ_ONLY, blankinit, errBuffer);

--- a/src/main/java/com/diablominer/DiabloMiner/DeviceState/GPUHardwareType.java
+++ b/src/main/java/com/diablominer/DiabloMiner/DeviceState/GPUHardwareType.java
@@ -198,19 +198,19 @@ public class GPUHardwareType extends HardwareType {
 		int platformCount = 0;
 
 		for(CLPlatform platform : platforms) {
-			float version;
+			PlatformVersion version;
 
 			diabloMiner.info("Using " + platform.getInfoString(CL10.CL_PLATFORM_NAME).trim() + " " + platform.getInfoString(CL10.CL_PLATFORM_VERSION));
 
 			String versions = platform.getInfoString(CL10.CL_PLATFORM_VERSION);
 			if(versions.contains("OpenCL 1.0"))
-				version = 1.0f;
+				version = PlatformVersion.V1_0;
 			else if (versions.contains("OpenCL 1.1"))
-				version = 1.1f;
+				version = PlatformVersion.V1_1;
 			else
-				version = 1.2f;
+				version = PlatformVersion.V1_2;
 
-			if(version == 1.0) {
+			if(version == PlatformVersion.V1_0) {
 				diabloMiner.error("OpenCL platform " + platform.getInfoString(CL10.CL_PLATFORM_NAME).trim() + " is not OpenCL 1.1 or later");
 				continue;
 			}

--- a/src/main/java/com/diablominer/DiabloMiner/DeviceState/PlatformVersion.java
+++ b/src/main/java/com/diablominer/DiabloMiner/DeviceState/PlatformVersion.java
@@ -1,0 +1,25 @@
+/*
+ * DiabloMiner - OpenCL miner for Bitcoin
+ * Copyright (C) 2010, 2011, 2012 Patrick McFarland <diablod3@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.diablominer.DiabloMiner.DeviceState;
+
+public enum PlatformVersion {
+  V1_0,
+  V1_1,
+  V1_2
+}


### PR DESCRIPTION
I was getting this exception:

```
[2/11/13 8:36:38 PM] Started
[2/11/13 8:36:38 PM] Connecting to: http://localhost:8332/
[2/11/13 8:36:38 PM] Using NVIDIA CUDA OpenCL 1.1 CUDA 4.2.1
[2/11/13 8:36:38 PM] Added GeForce GTX 560 Ti (#1) (8 CU, local work size of 1024)
[2/11/13 8:36:38 PM] ERROR: Failed to allocate blank buffer
DiabloMiner: An error occurred while starting the application.
```

I tracked it down to the the check for platform that was taking the wrong path:

``` java
if (platform_version == 1.1) {
// this is probably what is intended to run
} else {
// this is what is actually run
}
```

It's easy to forget to put an 'f' after a float literal,
which will cause comparison with a float to return false.

This could have obviously been fixed more simply by changing the above to

``` java
if (platform_version == 1.1f) { /*...*/ }
```

But it's an easy mistake to make, and you won't know until run-time that you've made it so thought this would be the safer way. If you'd like to address the issue another way, like using a String `"1.1"` feel free to close the request and fix however you'd like.

Thanks!
